### PR TITLE
Add SquashFS file option to lecture 7 

### DIFF
--- a/07_Extending_containers_with_virtual_environments_for_faster_testing/examples/extending_containers_with_venv.md
+++ b/07_Extending_containers_with_virtual_environments_for_faster_testing/examples/extending_containers_with_venv.md
@@ -6,24 +6,25 @@ This is a short example of how to extend the containers built via `cotainr` via 
 
 We assume you have built a container from a `conda` environment file via something like:
 ```bash
-module load LUMI/23.03 cotainr
-cotainr build minimal_pytorch.sif --base-image=/appl/local/containers/sif-images/lumi-rocm-rocm-5.6.1.sif --conda-env=minimal_pytorch.yml
+module use /appl/local/training/modules/AI-20241126
+module load cotainr
+cotainr build minimal_pytorch.sif --base-image=/appl/local/containers/sif-images/lumi-rocm-rocm-6.0.3.sif --conda-env=minimal_pytorch.yml --accept-license
 ```
 
-## Set up virtual environment
+## Set up a virtual environment
 
-First we run a shell inside the container
+First, we run a shell inside the container
 ```bash
 singularity shell --bind /pfs,/scratch,/projappl,/project,/flash,/appl minimal_pytorch.sif
 ```
 Note that setting `--bind` is optional, you achieve the same by
 ```bash
-module use /appl/local/training/modules/AI-20240529/
+module use /appl/local/training/modules/AI-20241126/
 module load singularity-userfilesystems
 singularity shell minimal_pytorch.sif
 ```
 
-In order to install additional packages we create a virtual environment via `venv` and activate it inside the container
+In order to install additional packages, we create a virtual environment via `venv` and activate it inside the container
 ```bash
 python -m venv myenv --system-site-packages
 source myenv/bin/activate
@@ -40,24 +41,24 @@ pip install torchmetrics
 ## Run container with `venv` packages
 If we want to run the container with the freshly installed packages in a batch script, we need to first source the `venv` before executing the python script:
 ```bash
-singularity exec $CONTAINER bash -c "source myenv/bin/activate && python my_script.py"
+singularity exec minimal_pytorch.sif bash -c "source myenv/bin/activate && python my_script.py"
 ```
 
 > [!WARNING]
-> You should not stop here as this way of installing python packages puts a lot of strain on the Lustre file system. Choose one of the following options next:
+> You should not stop here, as this way of installing python packages creates typically thousands of small files. This puts a lot of strain on the Lustre file system and might exceed your file quota. Choose one of the following options next:
 
 
 ## Option 1: Create a new container with `cotainr`
 After having found all packages needed for our project, we should create a new container with an updated `conda` environment file. The virtual environment should then be deleted
 ```bash
-cotainr build updated_pytorch.sif --base-image=/appl/local/containers/sif-images/lumi-rocm-rocm-5.6.1.sif --conda-env=updated_pytorch.yml
+cotainr build updated_pytorch.sif --base-image=/appl/local/containers/sif-images/lumi-rocm-rocm-6.0.3.sif --conda-env=updated_pytorch.yml --accept-license
 rm -rf myenv
 ```
 
 
 ## Option 2: Turn `myenv` into a SquashFS file
-Alternatively, we can also reduce the stress on the Lustre file system by turning the `myenv` directory to a SquashFS file and bind mount it to the container:
+Alternatively, we can turn the `myenv` directory into a SquashFS file and bind mount it to the container:
 ```bash
 mksquashfs myenv myenv.sqsh
-singularity exec -B myenv.sqsh:/user-software:image-src=/ $CONTAINER bash -c 'source /user-software/bin/activate && python my_script.py'
+singularity exec -B myenv.sqsh:/user-software:image-src=/ minimal_pytorch.sif bash -c 'source /user-software/bin/activate && python my_script.py'
 ```


### PR DESCRIPTION
This addition to lecture 7 shows how to turn the `venv` into a SquashFS file and access this new file from the container.

Fix #14 

The following lines might need to be updated:
```bash
module load LUMI/23.03 cotainr
--base-image=/appl/local/containers/sif-images/lumi-rocm-rocm-5.6.1.sif
```
Once lecture 6 is updated I will change these lines accordingly to make it consistent with previous lecture.